### PR TITLE
Git submodules for OAuth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "OAuth2Client"]
+	path = OAuth2Client
+	url = https://github.com/nxtbgthng/OAuth2Client.git


### PR DESCRIPTION
Hey! You should test this out but I think it helps :)

When cloning this app, it doesn't have OAuthClient, but using `.gitmodules` to manage it should make future clone-ers download a runnable source.
